### PR TITLE
fix tutorial bug

### DIFF
--- a/docs/ready-to-serve.html
+++ b/docs/ready-to-serve.html
@@ -107,7 +107,7 @@ The Web version of the <em>knock, knock</em> joke has less code than the text-mo
 
 
 <span class="k">if</span> <span class="vm">__name__</span> <span class="o">==</span> <span class="s2">&quot;__main__&quot;</span><span class="p">:</span>
-    <span class="n">quick_start</span><span class="p">(</span><span class="n">builder</span><span class="o">=</span><span class="n">story</span><span class="p">)</span>
+    <span class="n">quick_start</span><span class="p">(</span><span class="n">story_builder</span><span class="o">=</span><span class="n">story</span><span class="p">)</span>
 </pre></div>
 </div>
 <div class="section" id="the-perfect-host">


### PR DESCRIPTION
I was running through the tutorial page, and ran into this problem:
`TypeError: balladeer.lite.storybuilder.StoryBuilder.__init__() got multiple values for keyword argument 'world'`


But I did track it down: It seems in 84d32105dd5ebd5bc539804de28e41e519221970 `builder` became `story_builder` in the examples, but the tutorial wasn't updated.